### PR TITLE
Fix for padding in quest rewards

### DIFF
--- a/templates/wowhead/quest.tpl
+++ b/templates/wowhead/quest.tpl
@@ -368,7 +368,7 @@
 						<table class="icontab">
 						<tr>
 {section name=j loop=$quest.itemchoices}
-								<th id="icontab-icon{$smarty.section.j.index+1}"></th>
+								<th id="icontab-icon{$smarty.section.j.index}"></th>
 								<td>
 									<span class="q{$quest.itemchoices[j].quality}">
 										<a href="?item={$quest.itemchoices[j].entry}">
@@ -381,7 +381,7 @@
 						</table>
 						<script type="text/javascript">
 						{section name=j loop=$quest.itemchoices}
-							ge('icontab-icon{$smarty.section.j.index+1}').appendChild(g_items.createIcon({$quest.itemchoices[j].entry}, 1, {$quest.itemchoices[j].count}));
+							ge('icontab-icon{$smarty.section.j.index}').appendChild(g_items.createIcon({$quest.itemchoices[j].entry}, 1, {$quest.itemchoices[j].count}));
 						{/section}
 						</script>
 {/if}
@@ -393,7 +393,7 @@
 						<table class="icontab">
 						<tr>{strip}
 {section name=j loop=$quest.itemrewards}
-								<th id="icontab-icon{$smarty.section.j.index+1}"></th>
+								<th id="icontab-icon{$smarty.section.j.index+4}"></th>
 								<td>
 									<span class="q{$quest.itemrewards[j].quality}">
 										<a href="?item={$quest.itemrewards[j].entry}">
@@ -406,7 +406,7 @@
 						</table>
 						<script type="text/javascript">
 						{section name=j loop=$quest.itemrewards}
-							ge('icontab-icon{$smarty.section.j.index+1}').appendChild(g_items.createIcon({$quest.itemrewards[j].entry}, 1, {$quest.itemrewards[j].count}));
+							ge('icontab-icon{$smarty.section.j.index+4}').appendChild(g_items.createIcon({$quest.itemrewards[j].entry}, 1, {$quest.itemrewards[j].count}));
 						{/section}
 						</script>
 {/if}


### PR DESCRIPTION
Should fix https://github.com/MarkusNemesis/VanillaWoWDB2/issues/13

I checked most quests with pick a reward > 4 and you will receive either 1 or 2 items. Appears to have fixed the padding issues with the icons. Not sure if this breaks stuff somewhere else though!

Before:
![screen shot 2018-07-10 at 22 10 49](https://user-images.githubusercontent.com/18648426/42534863-21b803b2-848e-11e8-86fc-76e2aca33ab4.png)

After:
![screen shot 2018-07-10 at 22 11 08](https://user-images.githubusercontent.com/18648426/42534872-2af6e268-848e-11e8-9c8c-3533166df56d.png)
